### PR TITLE
Improve rmux and Ghostty mouse selection

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -2,6 +2,14 @@ command = /opt/homebrew/bin/fish --login --interactive
 
 window-inherit-working-directory = true
 
+# Preserve native terminal selection while TUIs or rmux have mouse reporting on.
+# Drag normally for app/rmux mouse behavior; Shift-drag for terminal selection.
+mouse-shift-capture = never
+
+# Match common terminal behavior: selection stays highlighted until explicitly
+# copied with the terminal copy shortcut.
+copy-on-select = false
+
 keybind = ctrl+shift+comma=reload_config
 
 keybind = ctrl+a>n=new_window

--- a/.config/rmux/rmux.conf
+++ b/.config/rmux/rmux.conf
@@ -1,10 +1,22 @@
-# Let rmux own wheel scrolling so mouse-aware TUIs do not capture scrollback.
+# Let rmux own mouse wheel scrolling by default.
+# Use Shift-drag in Ghostty for native terminal selection, or prefix+T to
+# temporarily disable rmux mouse mode for plain drag selection.
 set -g mouse on
+bind T if-shell -F '#{mouse}' 'set -g mouse off ; display-message "mouse OFF: native terminal selection enabled"' 'set -g mouse on ; display-message "mouse ON: rmux pane mouse mode enabled"'
 
 # Increase scrollback history.
 set -g history-limit 1000000
 
-# Enter rmux copy-mode on wheel-up even when the pane app requested mouse input.
+# Use vi-style keyboard selection in copy-mode and copy to the macOS clipboard.
+setw -g mode-keys vi
+set -s copy-command 'pbcopy'
+bind [ copy-mode
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+bind -T copy-mode-vi C-c send-keys -X copy-pipe-and-cancel
+
+# When rmux mouse mode is toggled on, enter copy-mode on wheel-up even when
+# the pane app requested mouse input.
 # While already in copy-mode, keep forwarding mouse events to copy-mode itself.
 unbind-key -n WheelUpPane
 bind-key -n WheelUpPane { if-shell -F '#{pane_in_mode}' { send-keys -M } { copy-mode -e; send-keys -X -N 5 scroll-up } }


### PR DESCRIPTION
## Summary
- keep Ghostty native selection available with Shift-drag while mouse reporting is active
- disable copy-on-select so terminal selection copies explicitly
- add rmux mouse, scrollback, copy-mode, clipboard, and prefix+T mouse-toggle config

## Verification
- `/Applications/Ghostty.app/Contents/MacOS/ghostty +validate-config --config-file=/Users/prabirshrestha/.dotfiles/.config/ghostty/config`
- throwaway `rmux` server loaded `.config/rmux/rmux.conf` and reported the expected mouse/history/copy bindings
- `git diff --check`